### PR TITLE
Support Firebase email template

### DIFF
--- a/android/src/main/java/com/turnoutt/firebase/dynamiclinks/CapacitorFirebaseDynamicLinks.kt
+++ b/android/src/main/java/com/turnoutt/firebase/dynamiclinks/CapacitorFirebaseDynamicLinks.kt
@@ -194,6 +194,17 @@ class CapacitorFirebaseDynamicLinks : Plugin() {
                     }
                     if (deepLink != null) {
                         val ret = JSObject()
+                        
+                        val intentData: Uri? = intent.data
+                        if (intentData != null) {
+                            val code: String = intentData.getQueryParameter("oobCode").orEmpty()
+                            val mode: String = intentData.getQueryParameter("mode").orEmpty()
+                            val parameter: String = intentData.toString()
+                            ret.put("code", code)
+                            ret.put("mode", mode)
+                            ret.put("parameter", parameter)
+                        }
+                        
                         ret.put("url", deepLink.toString())
                         notifyListeners(EVENT_DEEP_LINK, ret, true)
                     }


### PR DESCRIPTION
Firebase email template for authentication  does not url-encode the url part containing the appended parameters (code and mode). https://support.google.com/firebase/answer/7000714?authuser=1

Since it is a Firebase product and that in many use one would want to use the action link from the email as a deep link, i think it is a good idea to include these 2 parameters